### PR TITLE
add explanation on where to find the plugin - fix #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 The algorithm for relief shading is available in the official QGIS plugin repository and can be installed as usual (In QGIS go to Plugins -> Manage and install … ). Be sure to enable experimental plugins. 
 
+The tool will be available in the top level of the QGIS toolbox as a separate provider.
+
 If the standard installation does not work, the plugin can be downloaded for the repository (above) and installed manually: 
 First you need to locate your QGIS plugins folder. On Windows it would be ‘C:\users\username\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins’ (or just do a file search for ‘QGIS3’ …)
 


### PR DESCRIPTION
The line is taken from the discussion of #6, where it was proposed to add such a line.